### PR TITLE
Update KeyboardAvoidingView.js

### DIFF
--- a/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -110,14 +110,16 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
   };
 
   _onLayout = (event: ViewLayoutEvent) => {
-    this._frame = event.nativeEvent.layout;
+    if (!this.frame || this.props.behavior != 'height')
+      this._frame = event.nativeEvent.layout;
   };
 
   UNSAFE_componentWillUpdate(nextProps: Props, nextState: State): void {
     if (
       nextState.bottom === this.state.bottom &&
       this.props.behavior === 'height' &&
-      nextProps.behavior === 'height'
+      nextProps.behavior === 'height' &&
+      !this.frame
     ) {
       // If the component rerenders without an internal state change, e.g.
       // triggered by parent component re-rendering, no need for bottom to change.


### PR DESCRIPTION
fix issue when this.frame.height will never go back to its original value

Thank you for sending the PR! We appreciate you spending the time to work on these changes. 
Help us understand your motivation by explaining why you decided to make this change.

If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged.

Test Plan:
----------
Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!

Release Notes:
--------------
Help reviewers and the release process by writing your own release notes. See below for an example.

[CATEGORY] [TYPE] [LOCATION] - Message

<!--
  **INTERNAL and MINOR tagged notes will not be included in the next version's final release notes.**

    CATEGORY
  [----------]      TYPE
  [ CLI      ] [-------------]    LOCATION
  [ DOCS     ] [ BREAKING    ] [-------------]
  [ GENERAL  ] [ BUGFIX      ] [ {Component} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}  ]
  [ IOS      ] [ FEATURE     ] [ {Directory} ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework} ] - | {Message} |
  [----------] [-------------] [-------------]   |-----------|

 EXAMPLES:

 [IOS] [BREAKING] [FlatList] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [TextInput] - Did a thing to TextInput
 [CLI] [FEATURE] [local-cli/info/info.js] - CLI easier to do things with
 [DOCS] [BUGFIX] [GettingStarted.md] - Accidentally a thing/word
 [GENERAL] [ENHANCEMENT] [Yoga] - Added new yoga thing/position
 [INTERNAL] [FEATURE] [./scripts] - Added thing to script that nobody will see
-->
